### PR TITLE
Add reusable SEO component and meta tags for pages

### DIFF
--- a/cwn-react/src/App.jsx
+++ b/cwn-react/src/App.jsx
@@ -11,20 +11,17 @@ import {
   Blogs,
   PrivacyPolicy,
 } from "@pages";
-import { Helmet } from 'react-helmet';
-
-<Helmet>
-  <title>Code With Naqvi - Learn Web Development</title>
-  <meta name="description" content="Code With Naqvi offers React, Rails, and web dev tutorials." />
-  <meta name="keywords" content="React, Rails, Web Development, Code With Naqvi" />
-  <meta property="og:title" content="Code With Naqvi" />
-  <meta property="og:description" content="React and Rails tutorials for developers." />
-  <meta property="og:image" content="/cover-image.jpg" />
-</Helmet>
+import Seo from "@components/seo/Seo";
 
 export default function App() {
   return (
     <>
+      <Seo
+        title="Code With Naqvi - Learn Web Development"
+        description="Code With Naqvi offers React, Rails, and web dev tutorials."
+        keywords="React, Rails, Web Development, Code With Naqvi"
+        image="/cover-image.jpg"
+      />
       <Navbar />
       <Routes>
         <Route path="/" element={<Home />} />

--- a/cwn-react/src/components/seo/Seo.jsx
+++ b/cwn-react/src/components/seo/Seo.jsx
@@ -1,0 +1,19 @@
+/* eslint-disable react/prop-types */
+import { Helmet } from "react-helmet";
+
+export default function Seo({ title, description, keywords, image }) {
+  return (
+    <Helmet>
+      {title && <title>{title}</title>}
+      {description && (
+        <meta name="description" content={description} />
+      )}
+      {keywords && <meta name="keywords" content={keywords} />}
+      {title && <meta property="og:title" content={title} />}
+      {description && (
+        <meta property="og:description" content={description} />
+      )}
+      {image && <meta property="og:image" content={image} />}
+    </Helmet>
+  );
+}

--- a/cwn-react/src/pages/about/About.jsx
+++ b/cwn-react/src/pages/about/About.jsx
@@ -8,10 +8,16 @@ import Services from "@components/services/Services";
 import about from "@images/about/about-us.svg";
 import ourStory from "@images/about/our-story.svg";
 import Whatsapp from "../../components/Whatsapp_Logo/Whatsapp";
+import Seo from "@components/seo/Seo";
 
 export function About() {
   return (
     <main>
+      <Seo
+        title="About Us | Code With Naqvi"
+        description="Learn about CWN's mission and the team crafting innovative software solutions."
+        keywords="About CWN, Code With Naqvi, software company"
+      />
       {/* /////////////////  Header */}
       <Header
         heading="About us"

--- a/cwn-react/src/pages/blogs/Blogs.jsx
+++ b/cwn-react/src/pages/blogs/Blogs.jsx
@@ -1,3 +1,14 @@
+import Seo from "@components/seo/Seo";
+
 export function Blogs() {
-  return <div>Blogs</div>;
+  return (
+    <main>
+      <Seo
+        title="Blogs | Code With Naqvi"
+        description="Read the latest articles and tutorials on software and web development from CWN."
+        keywords="blogs, tutorials, Code With Naqvi"
+      />
+      <div>Blogs</div>
+    </main>
+  );
 }

--- a/cwn-react/src/pages/company/Company.jsx
+++ b/cwn-react/src/pages/company/Company.jsx
@@ -1,3 +1,14 @@
+import Seo from "@components/seo/Seo";
+
 export function Company() {
-  return <div>Company</div>;
+  return (
+    <main>
+      <Seo
+        title="Company | Code With Naqvi"
+        description="Learn about Code With Naqvi's company culture and values."
+        keywords="company, Code With Naqvi"
+      />
+      <div>Company</div>
+    </main>
+  );
 }

--- a/cwn-react/src/pages/courses/Courses.jsx
+++ b/cwn-react/src/pages/courses/Courses.jsx
@@ -4,6 +4,7 @@ import Contact from "@components/contact/contact";
 import Footer from "@components/footer/Footer";
 import Whatsapp from "../../components/Whatsapp_Logo/Whatsapp";
 import Header from "../../components/header/Header";
+import Seo from "@components/seo/Seo";
 
 import courseHeaderImg from "../../assets/images/courses/sir.jpeg";
 import htmlThumbnail from "../../assets/images/courses/html.jpeg";
@@ -16,6 +17,11 @@ import cppThumbnail from "../../assets/images/courses/c++.jpeg";
 export function Courses() {
   return (
     <main>
+      <Seo
+        title="Courses | Code With Naqvi"
+        description="Enhance your skills with CWN's programming courses and resources."
+        keywords="courses, programming, Code With Naqvi"
+      />
       <Header
         heading="Learn & become the Top 1% software developer"
         text="We have the best professors who teach web development to beginners, And help them to become high level developer and to dominate the market."

--- a/cwn-react/src/pages/home/Home.jsx
+++ b/cwn-react/src/pages/home/Home.jsx
@@ -38,6 +38,7 @@ import Whatsapp from "../../components/Whatsapp_Logo/Whatsapp";
 import challengeImg1 from "../../assets/images/challenge/img.svg";
 import challengeImg2 from "../../assets/images/challenge/img-2.svg";
 import challengeImg3 from "../../assets/images/challenge/img-3.svg";
+import Seo from "@components/seo/Seo";
 
 export function Home() {
   const brandLogos = [
@@ -52,6 +53,11 @@ export function Home() {
 
   return (
     <main>
+      <Seo
+        title="CWN - Software Product Development Company"
+        description="We build and scale modern software solutions that deliver business value."
+        keywords="CWN, Code With Naqvi, software development, web development"
+      />
       <header
         style={{
           background: `url(${homeBg}), linear-gradient(10deg, rgba(59, 130, 246, 0.00) 12.42%, rgba(62, 183, 187, 0.10) 63.32%)`,

--- a/cwn-react/src/pages/portfolio/Portfolio.jsx
+++ b/cwn-react/src/pages/portfolio/Portfolio.jsx
@@ -1,3 +1,14 @@
+import Seo from "@components/seo/Seo";
+
 export function Portfolio() {
-  return <div>Portfolio</div>;
+  return (
+    <main>
+      <Seo
+        title="Portfolio | Code With Naqvi"
+        description="Browse CWN's portfolio of successful software projects."
+        keywords="portfolio, projects, CWN"
+      />
+      <div>Portfolio</div>
+    </main>
+  );
 }

--- a/cwn-react/src/pages/privacy/PrivacyPolicy.jsx
+++ b/cwn-react/src/pages/privacy/PrivacyPolicy.jsx
@@ -1,8 +1,14 @@
 import Footer from "@components/footer/Footer";
+import Seo from "@components/seo/Seo";
 
 export function PrivacyPolicy() {
   return (
     <main>
+      <Seo
+        title="Privacy Policy | Code With Naqvi"
+        description="Review Code With Naqvi's privacy practices and how we handle your data."
+        keywords="privacy policy, Code With Naqvi"
+      />
       <div className="section mx-auto p-8 mt-12">
         <h1 className="text-3xl font-bold mb-2">Privacy Policy</h1>
         <p className="text-md mb-4 text-sub-para">

--- a/cwn-react/src/pages/services/Services.jsx
+++ b/cwn-react/src/pages/services/Services.jsx
@@ -9,10 +9,16 @@ import ServicesSection from "@components/services/Services";
 import services from "@images/services/services.svg";
 import project from "@images/services/project-manger.svg";
 import webDevelopment from "@images/services/web-development.svg";
+import Seo from "@components/seo/Seo";
 
 export function Services() {
   return (
     <main>
+      <Seo
+        title="Software Development Services | CWN"
+        description="Discover CWN's web development and project management services tailored to your business."
+        keywords="services, software development, CWN"
+      />
       {/* /////////////////  Header */}
       <Header
         heading="Services"

--- a/cwn-react/src/pages/solutions/Solutions.jsx
+++ b/cwn-react/src/pages/solutions/Solutions.jsx
@@ -10,10 +10,16 @@ import services from "@images/solutions/solution.svg";
 import innovation from "@images/solutions/innovation.svg";
 import development from "@images/solutions/development.svg";
 import developmentStrategy from "@images/solutions/development-strategy.svg";
+import Seo from "@components/seo/Seo";
 
 export function Solutions() {
   return (
     <main>
+      <Seo
+        title="Software Solutions | CWN"
+        description="Explore CWN's scalable software solutions and dedicated development support."
+        keywords="solutions, software development, CWN"
+      />
       {/* ///////////////////////   Header */}
       <Header
         heading="Startup Software Development"


### PR DESCRIPTION
## Summary
- add reusable `<Seo>` component for managing meta tags
- integrate SEO metadata across core pages and default layout

## Testing
- `npx --prefix cwn-react eslint cwn-react --ext js,jsx --resolve-plugins-relative-to cwn-react --config .eslintrc.cjs` (fails: `'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aa334088ec832a9045cd29d8435dc0