### PR TITLE
style: revamp courses section cards

### DIFF
--- a/cwn-react/src/pages/courses/Courses.jsx
+++ b/cwn-react/src/pages/courses/Courses.jsx
@@ -52,8 +52,8 @@ export function Courses() {
           </div>
         </div>
       </section>
-      <section className="section mb-32">
-        <h2 className="h2">Level up your web development skills</h2>
+      <section className="section mb-32 bg-gray-50 py-16 rounded-xl">
+        <h2 className="h2 text-center mb-12">Level up your web development skills</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-12">
           <CourseCard
             thumbnail={htmlThumbnail}
@@ -83,7 +83,7 @@ export function Courses() {
             link={
               "https://www.youtube.com/watch?v=oC2NQVvhzTk&list=PL9WbyKqkuCAajVIrT9lFBQduvh9P7tGSb"
             }
-            title={"The Creative CSS Course"}
+            title={"The Creative JavaScript Course"}
             description={
               "JavaScript is a versatile programming language used primarily for creating interactive and dynamic web content."
             }
@@ -137,24 +137,24 @@ export function Courses() {
 
 function CourseCard({ thumbnail, thumbnailAlt, title, description, link }) {
   return (
-    <div className="rounded-xl shadow-xl">
-      <a href={link}>
-        <img className="rounded-t-xl" src={thumbnail} alt={thumbnailAlt} />
-      </a>
-      <div className="px-5 py-10">
-        <h3 className="mb-4 text-2xl font-semibold text-sub-heading   ">
-          {title}
-        </h3>
-        <p className="mb-8 text-para">{description}</p>
-        <a
-          href={link}
-          target="_blank"
-          className="px-5 py-3 text-white text-lg font-semibold bg-main rounded-lg"
-          rel="noreferrer"
-        >
-          View Courses
-        </a>
+    <a
+      href={link}
+      target="_blank"
+      rel="noreferrer"
+      className="group block rounded-xl overflow-hidden bg-white shadow-md transition-transform duration-300 hover:-translate-y-1 hover:shadow-2xl cursor-pointer"
+    >
+      <img
+        className="w-full h-48 object-cover transition-transform duration-300 group-hover:scale-105"
+        src={thumbnail}
+        alt={thumbnailAlt}
+      />
+      <div className="p-6">
+        <h3 className="mb-3 text-2xl font-semibold text-sub-heading">{title}</h3>
+        <p className="mb-6 text-para">{description}</p>
+        <span className="inline-block px-5 py-3 text-white text-lg font-semibold bg-main rounded-lg group-hover:bg-main-shade transition-colors duration-300">
+          View Playlist
+        </span>
       </div>
-    </div>
+    </a>
   );
 }


### PR DESCRIPTION
## Summary
- restyle courses section with light background for a cleaner layout
- make entire course cards link to relevant YouTube playlists
- correct JavaScript course card title

## Testing
- `NODE_PATH=$(pwd)/node_modules npm run lint` *(fails: react/jsx-no-target-blank, react/no-unescaped-entities, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa377b92fc832aa6e2268524a7da4e