### PR TITLE
Clear contact form errors and restore rectangular chat icons

### DIFF
--- a/cwn-react/src/components/Whatsapp_Logo/Whatsapp.jsx
+++ b/cwn-react/src/components/Whatsapp_Logo/Whatsapp.jsx
@@ -41,7 +41,7 @@ export default function Whatsapp() {
         <img
           src={WhatsappImg}
           alt="WhatsApp"
-          className="w-16 rounded-full shadow-lg cursor-pointer transition-transform transform hover:scale-105"
+          className="w-16 shadow-lg cursor-pointer transition-transform transform hover:scale-105"
           onClick={toggleChatbox}
         />
       </div>
@@ -51,7 +51,7 @@ export default function Whatsapp() {
           <img
             src={PhoneImg}
             alt="WhatsApp"
-            className="w-12 rounded-full shadow-lg cursor-pointer transition-transform transform hover:scale-105"
+            className="w-12 shadow-lg cursor-pointer transition-transform transform hover:scale-105"
           />
         </a>
       </div>
@@ -68,7 +68,7 @@ export default function Whatsapp() {
                 <img
                   src={WhatsappImg}
                   alt="WhatsApp logo"
-                  className="w-10 h-22 rounded-full"
+                  className="w-10 h-22"
                 />
                 <div>
                   <p className="font-semibold text-md text-white mb-1">

--- a/cwn-react/src/components/contact/contact.jsx
+++ b/cwn-react/src/components/contact/contact.jsx
@@ -18,9 +18,38 @@ export default function Contact() {
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
+    const fieldValue = type === "checkbox" ? checked : value;
+
     setFormData({
       ...formData,
-      [name]: type === "checkbox" ? checked : value,
+      [name]: fieldValue,
+    });
+
+    // Clear field-specific errors once the input is valid
+    setErrors((prevErrors) => {
+      const updatedErrors = { ...prevErrors };
+      switch (name) {
+        case "name":
+          if (fieldValue.trim()) delete updatedErrors.name;
+          break;
+        case "email":
+          if (
+            fieldValue.trim() &&
+            /^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/.test(fieldValue)
+          ) {
+            delete updatedErrors.email;
+          }
+          break;
+        case "contact_message":
+          if (fieldValue.trim()) delete updatedErrors.contact_message;
+          break;
+        case "terms_and_conditions":
+          if (fieldValue) delete updatedErrors.terms_and_conditions;
+          break;
+        default:
+          break;
+      }
+      return updatedErrors;
     });
   };
 


### PR DESCRIPTION
## Summary
- Clear form field errors when inputs become valid
- Remove circular styling from WhatsApp icons for rectangular display

## Testing
- `npx eslint --resolve-plugins-relative-to . . --ext js,jsx` *(fails: react/jsx-no-target-blank, react/no-unescaped-entities)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aa5c42fe10832a88229494d76f9512