### PR TITLE
Show red asterisks on contact form validation errors

### DIFF
--- a/cwn-react/src/components/contact/contact.jsx
+++ b/cwn-react/src/components/contact/contact.jsx
@@ -159,7 +159,7 @@ export default function Contact() {
                   onChange={handleChange}
                 ></textarea>
                 {errors.contact_message && (
-                  <p className="text-red-500 text-sm mt-1">* {errors.contact_message}</p>
+                  <p className="error-text text-sm mt-1">* {errors.contact_message}</p>
                 )}
               </div>
 
@@ -210,7 +210,7 @@ export default function Contact() {
                     </span>
                   </label>
                   {errors.terms_and_conditions && (
-                    <p className="text-red-500 text-sm mt-1">* {errors.terms_and_conditions}</p>
+                    <p className="error-text text-sm mt-1">* {errors.terms_and_conditions}</p>
                   )}
                 </div>
               </div>
@@ -253,7 +253,7 @@ function Input({ name, type, placeholder, value, onChange, error }) {
         value={value}
         onChange={onChange}
       />
-      {error && <p className="text-red-500 text-sm mt-1">* {error}</p>}
+      {error && <p className="error-text text-sm mt-1">* {error}</p>}
     </div>
   );
 }

--- a/cwn-react/src/components/contact/contact.jsx
+++ b/cwn-react/src/components/contact/contact.jsx
@@ -159,7 +159,7 @@ export default function Contact() {
                   onChange={handleChange}
                 ></textarea>
                 {errors.contact_message && (
-                  <p className="text-red-500 text-sm mt-1">{errors.contact_message}</p>
+                  <p className="text-red-500 text-sm mt-1">* {errors.contact_message}</p>
                 )}
               </div>
 
@@ -210,7 +210,7 @@ export default function Contact() {
                     </span>
                   </label>
                   {errors.terms_and_conditions && (
-                    <p className="text-red-500 text-sm mt-1">{errors.terms_and_conditions}</p>
+                    <p className="text-red-500 text-sm mt-1">* {errors.terms_and_conditions}</p>
                   )}
                 </div>
               </div>
@@ -253,7 +253,7 @@ function Input({ name, type, placeholder, value, onChange, error }) {
         value={value}
         onChange={onChange}
       />
-      {error && <p className="text-red-500 text-sm mt-1">{error}</p>}
+      {error && <p className="text-red-500 text-sm mt-1">* {error}</p>}
     </div>
   );
 }

--- a/cwn-react/src/css/index.css
+++ b/cwn-react/src/css/index.css
@@ -81,6 +81,10 @@
   .animate-fade-up {
     animation: fade-up 0.6s ease-out forwards;
   }
+
+  .error-text {
+    color: red;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- prepend `*` to contact form error messages and style in red

## Testing
- `npx eslint . --ext js,jsx --config ../.eslintrc.cjs --resolve-plugins-relative-to ./node_modules --report-unused-disable-directives --max-warnings 0` *(fails: numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5dea09a8832a8f6214d7bf619651