### PR TITLE
Refine mobile navbar for cleaner mobile view

### DIFF
--- a/cwn-react/src/components/navbar/Navbar.jsx
+++ b/cwn-react/src/components/navbar/Navbar.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/prop-types */
-/* eslint-disable no-unused-vars */
 import "../../css/index.css";
 import logo from "@icons/logo.svg";
 import mail from "@icons/mail.svg";
@@ -59,8 +58,8 @@ export default function Navbar() {
           <ul
             className={
               isMenuOpen
-                ? "absolute pl-8 right-0 top-full flex flex-col py-8 gap-10 bg-white border-b-[1px] border-sub duration-500 ease-out w-screen xlg:flex-row xlg:py-0 xlg:w-fit xlg:border-none xlg:gap-12 xlg:static z-50"
-                : "absolute pl-8 right-full top-full flex flex-col py-8 gap-10 bg-white border-b-[1px] border-sub duration-500 ease-out w-screen xlg:flex-row xlg:py-0 xlg:w-fit xlg:border-none xlg:gap-12 xlg:static z-50"
+                ? "absolute pl-8 right-0 top-full flex flex-col py-8 gap-10 bg-white border-b-[1px] border-sub duration-500 ease-out w-screen min-h-screen xlg:flex-row xlg:py-0 xlg:w-fit xlg:border-none xlg:gap-12 xlg:static z-50"
+                : "absolute pl-8 right-full top-full flex flex-col py-8 gap-10 bg-white border-b-[1px] border-sub duration-500 ease-out w-screen min-h-screen xlg:flex-row xlg:py-0 xlg:w-fit xlg:border-none xlg:gap-12 xlg:static z-50"
             }
           >
             {navLinks.map((link, i) => {
@@ -71,7 +70,6 @@ export default function Navbar() {
               href={"#contact"}
               styles="sm:hidden w-fit"
             />
-            <ContactInfo containerStyles={"sm:hidden bg-white"} />
           </ul>
         </div>
         <div className="flex gap-4">


### PR DESCRIPTION
## Summary
- hide contact details from mobile navigation
- expand mobile menu to full screen height

## Testing
- `npm run lint` *(fails: ESLint: missing plugin or existing project lint errors)*
- `npx eslint src/components/navbar/Navbar.jsx --ext js,jsx`

------
https://chatgpt.com/codex/tasks/task_e_68aa6686be50832a80016c754b8c7825