### PR TITLE
fix: improve home awards and why-choose-us responsiveness

### DIFF
--- a/cwn-react/src/components/Awards/Awards.jsx
+++ b/cwn-react/src/components/Awards/Awards.jsx
@@ -9,12 +9,12 @@ export default function Awards() {
     <>
       <section className="section mb-32">
         <h2 className="h2">Awards & recognitions</h2>
-        <div className="flex justify-between flex-wrap">
-          <img src={logo1} alt="logo1" className="max-h-44" />
-          <img src={logo2} alt="logo2" className="max-h-44" />
-          <img src={logo3} alt="logo3" className="max-h-44" />
-          <img src={logo4} alt="logo4" className="max-h-44" />
-          <img src={logo5} alt="logo5" className="max-h-44" />
+        <div className="flex flex-wrap items-center justify-center gap-6 sm:gap-10">
+          <img src={logo1} alt="logo1" className="h-24 sm:h-32 object-contain" />
+          <img src={logo2} alt="logo2" className="h-24 sm:h-32 object-contain" />
+          <img src={logo3} alt="logo3" className="h-24 sm:h-32 object-contain" />
+          <img src={logo4} alt="logo4" className="h-24 sm:h-32 object-contain" />
+          <img src={logo5} alt="logo5" className="h-24 sm:h-32 object-contain" />
         </div>
       </section>
     </>

--- a/cwn-react/src/components/why-choose-us/WhyChooseUs.jsx
+++ b/cwn-react/src/components/why-choose-us/WhyChooseUs.jsx
@@ -54,28 +54,28 @@ export default function WhyChooseUS() {
             </h2>
             <img src={arrow} alt="arrow" />
           </div>
-          <div className="flex flex-wrap gap-4 mb-2">
-            <div className="flex flex-1 gap-4 md:gap-6 bg-white p-2 px-4 items-center rounded-md">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-2">
+            <div className="flex gap-4 md:gap-6 bg-white p-2 px-4 items-center rounded-md justify-between sm:justify-start">
               <p className="text-para text-sm md:text-base">
                 Products delivered:
               </p>
               <p className="text-main text-lg font-medium">120+</p>
             </div>
-            <div className="flex flex-1 gap-4 md:gap-6 bg-white p-2 px-4 items-center rounded-md">
+            <div className="flex gap-4 md:gap-6 bg-white p-2 px-4 items-center rounded-md justify-between sm:justify-start">
               <p className="text-para text-sm md:text-base">
                 Years on the market:
               </p>
               <p className="text-main text-lg font-medium">10</p>
             </div>
           </div>
-          <div className="flex flex-wrap gap-4">
-            <div className="flex flex-1 gap-4 md:gap-6 bg-white p-2 px-4 items-center rounded-md">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="flex gap-4 md:gap-6 bg-white p-2 px-4 items-center rounded-md justify-between sm:justify-start">
               <p className="text-para text-sm md:text-base">
                 Client satisfaction rate:
               </p>
               <p className="text-main text-lg font-medium">99.9%</p>
             </div>
-            <div className="flex flex-1 gap-4 md:gap-6 bg-white p-2 px-4 items-center rounded-md">
+            <div className="flex gap-4 md:gap-6 bg-white p-2 px-4 items-center rounded-md justify-between sm:justify-start">
               <p className="text-para text-sm md:text-base">
                 Awards & certifications:
               </p>


### PR DESCRIPTION
## Summary
- center award logos and size them responsively
- use grid layout for “Why choose us” metrics on small screens

## Testing
- `npx eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0` *(fails: missing prop-types, unescaped entities, and other lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aab23ca790832ab47d17d7bd582037