### PR TITLE
Refactor mobile navigation overlay

### DIFF
--- a/cwn-react/src/components/navbar/Navbar.jsx
+++ b/cwn-react/src/components/navbar/Navbar.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/prop-types */
-/* eslint-disable no-unused-vars */
 import "../../css/index.css";
 import logo from "@icons/logo.svg";
 import mail from "@icons/mail.svg";
@@ -55,38 +54,40 @@ export default function Navbar() {
         <Link to="/">
           <img src={logo} alt="cwn logo" className={"w-32 sm:w-[160px]"} />
         </Link>
-        <div>
-          <ul
-            className={
-              isMenuOpen
-                ? "absolute pl-8 right-0 top-full flex flex-col py-8 gap-10 bg-white border-b-[1px] border-sub duration-500 ease-out w-screen xlg:flex-row xlg:py-0 xlg:w-fit xlg:border-none xlg:gap-12 xlg:static z-50"
-                : "absolute pl-8 right-full top-full flex flex-col py-8 gap-10 bg-white border-b-[1px] border-sub duration-500 ease-out w-screen xlg:flex-row xlg:py-0 xlg:w-fit xlg:border-none xlg:gap-12 xlg:static z-50"
-            }
-          >
-            {navLinks.map((link, i) => {
-              return <NavLink link={link} key={i} onToggleNav={toggleNav} />;
-            })}
-            <Button
-              text={"Start a Project"}
-              href={"#contact"}
-              styles="sm:hidden w-fit"
-            />
-            <ContactInfo containerStyles={"sm:hidden bg-white"} />
-          </ul>
-        </div>
-        <div className="flex gap-4">
-          <Button
-            text={"Start a Project"}
-            href={"#contact"}
-            styles="hidden sm:block"
-          />
+
+        {/* Desktop navigation */}
+        <ul className="hidden xlg:flex gap-12 items-center">
+          {navLinks.map((link, i) => (
+            <NavLink link={link} key={i} onToggleNav={toggleNav} />
+          ))}
+          <Button text={"Start a Project"} href={"#contact"} />
+        </ul>
+
+        {/* Mobile menu icon */}
+        {!isMenuOpen && (
           <img
-            src={isMenuOpen ? cross : menu}
+            src={menu}
             alt="menu"
             className="w-9 cursor-pointer xlg:hidden"
             onClick={toggleNav}
           />
-        </div>
+        )}
+
+        {/* Mobile navigation overlay */}
+        {isMenuOpen && (
+          <ul className="fixed inset-0 flex flex-col items-center justify-center gap-8 bg-white z-50 xlg:hidden">
+            <img
+              src={cross}
+              alt="close menu"
+              className="absolute top-4 right-4 w-9 cursor-pointer"
+              onClick={toggleNav}
+            />
+            {navLinks.map((link, i) => (
+              <NavLink link={link} key={i} onToggleNav={toggleNav} />
+            ))}
+            <Button text={"Start a Project"} href={"#contact"} />
+          </ul>
+        )}
       </div>
     </nav>
   );
@@ -94,7 +95,7 @@ export default function Navbar() {
 
 function NavLink({ link, onToggleNav }) {
   return (
-    <li className="w-full">
+    <li className="w-full text-center xlg:w-fit">
       <Link
         to={link.path}
         className="hover:text-main-shade duration-300 block text-para"


### PR DESCRIPTION
## Summary
- redesign mobile navigation to use full-screen overlay
- center nav links and add prominent start project link

## Testing
- `npm run lint -- --resolve-plugins-relative-to ./node_modules` *(fails: prop-types warnings and target="_blank" security issues)*

------
https://chatgpt.com/codex/tasks/task_e_68aad8461568832aa74cd98bc96fcbfb