### PR TITLE
chore: silence React Router v7 warnings

### DIFF
--- a/cwn-react/src/main.jsx
+++ b/cwn-react/src/main.jsx
@@ -6,7 +6,9 @@ import { BrowserRouter } from "react-router-dom";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
       <App />
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- add React Router v7 `future` flags to `BrowserRouter` to avoid console warnings

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react"; attempted to install but registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aadcd6d8e0832a807bb8def9990666