### PR TITLE
feat: add caching headers and improve color contrast

### DIFF
--- a/cwn-react/public/_headers
+++ b/cwn-react/public/_headers
@@ -1,0 +1,8 @@
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.js
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.css
+  Cache-Control: public, max-age=31536000, immutable

--- a/cwn-react/src/pages/home/Home.jsx
+++ b/cwn-react/src/pages/home/Home.jsx
@@ -61,12 +61,22 @@ export function Home() {
       />
       <AnimatedSection
         as="header"
-        style={{
-          background: `url(${homeBg}), linear-gradient(10deg, rgba(59, 130, 246, 0.00) 12.42%, rgba(62, 183, 187, 0.10) 63.32%)`,
-        }}
-        className="section"
+        className="section relative overflow-hidden"
       >
-        <div className=" py-24 lg:py-36">
+        <img
+          src={homeBg}
+          alt=""
+          fetchpriority="high"
+          className="absolute inset-0 w-full h-full object-cover"
+        />
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            background:
+              "linear-gradient(10deg, rgba(59, 130, 246, 0.00) 12.42%, rgba(62, 183, 187, 0.10) 63.32%)",
+          }}
+        />
+        <div className="py-24 lg:py-36">
           <span className="bg-main text-xs sm:text-sm lg:text-base rounded-lg py-1 px-3 text-white mb-2 inline-block">
             SOFTWARE PRODUCT DEVELOPMENT COMPANY
           </span>

--- a/cwn-react/tailwind.config.js
+++ b/cwn-react/tailwind.config.js
@@ -17,12 +17,12 @@ export default {
       }
     },
     colors: {
-      'main': "#3EB7BB",
-      'main-tint': "#66c9cc",
-      'main-tint-1': "#94D9DB",
-      'main-shade': "#1E9799",
+      'main': "#125F60",
+      'main-tint': "#3EB7BB",
+      'main-tint-1': "#66c9cc",
+      'main-shade': "#0F4F51",
       'main-mint': "#f0f9fa",
-      'main-dark': "#125F60",
+      'main-dark': "#0B3A3B",
       'secondary': "#FAFAFA",
       'tertiary': "#ED8B00",
       'tertiary-shade': "#d17a01",


### PR DESCRIPTION
## Summary
- ensure long-lived cache policy for built assets via Netlify headers
- darken primary theme colors to meet accessibility contrast guidelines
- prioritize hero image with fetchpriority to improve Largest Contentful Paint
- include caching headers for top-level JS and CSS bundles for better repeat-load performance

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaeba0c694832aafa2e6f4bd7fe32f