### PR TITLE
fix spacing issue in home hero heading

### DIFF
--- a/cwn-react/src/pages/home/Home.jsx
+++ b/cwn-react/src/pages/home/Home.jsx
@@ -81,12 +81,9 @@ export function Home() {
             SOFTWARE PRODUCT DEVELOPMENT COMPANY
           </span>
           <h1 className="font-bold text-4xl lg:text-8xl md:text-7xl sm:text-5xl mb-2 xl:w-10/12">
-            Your
-            <span className="text-main"> Product.</span>
-            Your
-            <span className="text-main"> Idea.</span> Our
-            <span className="text-main"> Innovation </span>
-            and Engineering.
+            Your <span className="text-main">Product.</span>{" "}
+            Your <span className="text-main">Idea.</span> Our{" "}
+            <span className="text-main">Innovation</span> and Engineering.
           </h1>
           <p className="text-sub-para text-lg sm:text-xl lg:text-2xl sm:w-10/12 lg:w-1/2 mb-10">
             We are committed to grow your business with modern technologies,


### PR DESCRIPTION
## Summary
- add missing spaces in homepage hero heading text

## Testing
- `npx eslint . --ext js,jsx --resolve-plugins-relative-to . --report-unused-disable-directives --max-warnings 0` *(fails: 24 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ab429f8bf4832ab9ece9ac67c6c8ba