### PR TITLE
Add Learning section to homepage

### DIFF
--- a/cwn-react/src/components/learning/Learning.jsx
+++ b/cwn-react/src/components/learning/Learning.jsx
@@ -1,0 +1,62 @@
+import AnimatedSection from "@components/AnimatedSection/AnimatedSection";
+import { Link } from "react-router-dom";
+import htmlThumbnail from "@images/courses/html.jpeg";
+import cssThumbnail from "@images/courses/css.jpeg";
+import jsThumbnail from "@images/courses/js.jpeg";
+
+export default function Learning() {
+  const resources = [
+    {
+      img: htmlThumbnail,
+      alt: "HTML Basics thumbnail",
+      title: "HTML Basics",
+      description: "Build a solid foundation with semantic HTML5.",
+      link: "/blogs",
+    },
+    {
+      img: cssThumbnail,
+      alt: "CSS Mastery thumbnail",
+      title: "CSS Mastery",
+      description: "Craft beautiful, responsive layouts with modern CSS.",
+      link: "/blogs",
+    },
+    {
+      img: jsThumbnail,
+      alt: "JavaScript Essentials thumbnail",
+      title: "JavaScript Essentials",
+      description: "Add interactivity with powerful JavaScript techniques.",
+      link: "/blogs",
+    },
+  ];
+
+  return (
+    <AnimatedSection className="section mb-32">
+      <h2 className="h2 mb-12">Learning Resources</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-12">
+        {resources.map((res) => (
+          <AnimatedSection
+            key={res.title}
+            as={Link}
+            to={res.link}
+            className="group block h-full rounded-xl overflow-hidden bg-white shadow-md transition-transform duration-300 hover:-translate-y-1 hover:shadow-2xl hover:scale-105"
+          >
+            <img
+              loading="lazy"
+              src={res.img}
+              alt={res.alt}
+              className="w-full h-48 object-cover transition-transform duration-300 group-hover:scale-110"
+            />
+            <div className="p-6">
+              <h3 className="mb-3 text-2xl font-semibold text-sub-heading">{res.title}</h3>
+              <p className="mb-6 text-para">{res.description}</p>
+              <span className="inline-block px-5 py-3 text-white text-lg font-semibold bg-main rounded-lg group-hover:bg-main-shade transition-colors duration-300">
+                Learn More
+              </span>
+            </div>
+          </AnimatedSection>
+        ))}
+      </div>
+    </AnimatedSection>
+  );
+}
+

--- a/cwn-react/src/pages/home/Home.jsx
+++ b/cwn-react/src/pages/home/Home.jsx
@@ -31,8 +31,6 @@ import Footer from "@components/footer/Footer";
 import WhoAeAre from "@components/who-we-are/WhoWeAre";
 import BookCall from "@components/book-call/BookCall";
 import Services from "@components/services/Services";
-import WhyChooseUS from "../../components/why-choose-us/WhyChooseUs";
-import Awards from "../../components/Awards/Awards";
 // import Certificates from "../../components/Certificates/certificates";
 import Whatsapp from "../../components/Whatsapp_Logo/Whatsapp";
 import challengeImg1 from "../../assets/images/challenge/img.svg";
@@ -40,6 +38,7 @@ import challengeImg2 from "../../assets/images/challenge/img-2.svg";
 import challengeImg3 from "../../assets/images/challenge/img-3.svg";
 import Seo from "@components/seo/Seo";
 import AnimatedSection from "@components/AnimatedSection/AnimatedSection";
+import Learning from "@components/learning/Learning";
 
 export function Home() {
   const brandLogos = [
@@ -66,7 +65,7 @@ export function Home() {
         <img
           src={homeBg}
           alt=""
-          fetchpriority="high"
+          fetchPriority="high"
           className="absolute inset-0 w-full h-full object-cover pointer-events-none"
         />
         <div
@@ -241,8 +240,8 @@ export function Home() {
         </div>
       </AnimatedSection>
 
-  
-     
+      <Learning />
+
       {/* <Certificates /> */}
       <Whatsapp />
 


### PR DESCRIPTION
## Summary
- add Learning component displaying HTML, CSS, and JavaScript resources
- include Learning section on homepage and fix hero image fetchPriority attribute

## Testing
- `npx eslint src/components/learning/Learning.jsx src/pages/home/Home.jsx --config ../.eslintrc.cjs --resolve-plugins-relative-to .`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba897df958832aa49d43c4f7173e00